### PR TITLE
Add Laravel 13 and Testbench 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [13.*, 12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.8

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0|^13.0",
         "inertiajs/inertia-laravel": "^2.0",
         "spatie/laravel-package-tools": "^1.16",
         "tightenco/ziggy": "^2.5"
@@ -25,7 +25,7 @@
         "larastan/larastan": "^2.9|^3.0",
         "laravel/pint": "^1.20",
         "nunomaduro/collision": "^7.10.0|^8.1.1",
-        "orchestra/testbench": "^8.22.0|^9.0.0|^10.0.0",
+        "orchestra/testbench": "^8.22.0|^9.0.0|^10.0.0|^11.0.0",
         "pestphp/pest": "^2.34|^3.0",
         "pestphp/pest-plugin-arch": "^2.7|^3.0",
         "pestphp/pest-plugin-laravel": "^2.3|^3.0",

--- a/workbench/storage
+++ b/workbench/storage
@@ -1,1 +1,0 @@
-/Users/smef/Code/Gearbox/email-logger/vendor/orchestra/testbench-core/laravel/storage


### PR DESCRIPTION
Adds Laravel 13 support by widening illuminate/contracts constraints and adding Testbench 11 support in composer.json.

Updated the CI matrix in workflows/run-tests.yml to test Laravel 13 / Testbench 11.

Verified locally by running `composer test`:

Tests: 13 passed (36 assertions)

Working in my use case; hopefully this works for others. Thanks for the package!